### PR TITLE
feat: add optional input to fail based on DeveloperHub settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ A full example of the `axe-devhub-action` can be seen at [`.github/workflows/tes
 
 ## Inputs
 
-| name           | description                                                                                                 | required           | default                |
-| -------------- | ----------------------------------------------------------------------------------------------------------- | ------------------ | ---------------------- |
-| `api_key`      | Your axe Watcher API key                                                                                    | :white_check_mark: |                        |
-| `server_url`   | Axe server URL                                                                                              | :x:                | https://axe.deque.com  |
-| `retry_count`  | Number of times to retry                                                                                    | :x:                | 10                     |
-| `github-token` | Optional [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) | :x:                | `secrets.GITHUB_TOKEN` |
+| name                         | description                                                                                                 | required           | default                |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------ | ---------------------- |
+| `api_key`                    | Your axe Watcher API key                                                                                    | :white_check_mark: |                        |
+| `server_url`                 | Axe server URL                                                                                              | :x:                | https://axe.deque.com  |
+| `retry_count`                | Number of times to retry                                                                                    | :x:                | 10                     |
+| `github-token`               | Optional [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) | :x:                | `secrets.GITHUB_TOKEN` |
+| `issues_over_a11y_threshold` | Number of issues over your A11y Threshold settings within DeveloperHub                                      | :x:                | `false`                |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A full example of the `axe-devhub-action` can be seen at [`.github/workflows/tes
 
 ## Inputs
 
-| name                         | description                                                                                                 | required           | default                |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------ | ---------------------- |
-| `api_key`                    | Your axe Watcher API key                                                                                    | :white_check_mark: |                        |
-| `server_url`                 | Axe server URL                                                                                              | :x:                | https://axe.deque.com  |
-| `retry_count`                | Number of times to retry                                                                                    | :x:                | 10                     |
-| `github-token`               | Optional [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) | :x:                | `secrets.GITHUB_TOKEN` |
-| `issues_over_a11y_threshold` | Number of issues over your A11y Threshold settings within DeveloperHub                                      | :x:                | `false`                |
+| name                    | description                                                                                                              | required           | default                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------ | ---------------------- |
+| `api_key`               | Your axe Watcher API key                                                                                                 | :white_check_mark: |                        |
+| `server_url`            | Axe server URL                                                                                                           | :x:                | https://axe.deque.com  |
+| `retry_count`           | Number of times to retry                                                                                                 | :x:                | 10                     |
+| `github-token`          | Optional [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)              | :x:                | `secrets.GITHUB_TOKEN` |
+| `enable_a11y_threshold` | Enable the a11y threshold, which will cause the action to fail if the number of violations is greater than the threshold | :x:                | `false`                |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: number of times to attempt fetching the commit status
     required: false
     default: 10
+  issues_over_a11y_threshold:
+    description: Number of issues over your A11y Threshold settings within DeveloperHub
+    required: false
+    default: "false"
   github_token:
     description: GitHub token
     default: ${{ github.token }}
@@ -42,6 +46,7 @@ runs:
         SERVER_URL: ${{ inputs.server_url }}
         RETRY_COUNT: ${{ inputs.retry_count }}
         COMMIT_SHA: ${{ github.sha }}
+        ISSUES_OVER_A11Y_THRESHOLD: ${{ inputs.issues_over_a11y_threshold }}
     # Add a comment reporting the number of violations.
     - if: ${{ failure() }}
       uses: marocchino/sticky-pull-request-comment@v2

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,9 @@ inputs:
     default: 10
   enable_a11y_threshold:
     description: Enable the a11y threshold, which will cause the action to fail if the number of violations is greater than the threshold
+    type: boolean
+    default: false
     required: false
-    default: "false"
   github_token:
     description: GitHub token
     default: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,8 @@ inputs:
     description: number of times to attempt fetching the commit status
     required: false
     default: 10
-  issues_over_a11y_threshold:
-    description: Number of issues over your A11y Threshold settings within DeveloperHub
+  enable_a11y_threshold:
+    description: Enable the a11y threshold, which will cause the action to fail if the number of violations is greater than the threshold
     required: false
     default: "false"
   github_token:
@@ -46,7 +46,7 @@ runs:
         SERVER_URL: ${{ inputs.server_url }}
         RETRY_COUNT: ${{ inputs.retry_count }}
         COMMIT_SHA: ${{ github.sha }}
-        ISSUES_OVER_A11Y_THRESHOLD: ${{ inputs.issues_over_a11y_threshold }}
+        ENABLE_A11Y_THRESHOLD: ${{ inputs.enable_a11y_threshold }}
     # Add a comment reporting the number of violations.
     - if: ${{ failure() }}
       uses: marocchino/sticky-pull-request-comment@v2

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,8 @@ inputs:
     default: 10
   enable_a11y_threshold:
     description: Enable the a11y threshold, which will cause the action to fail if the number of violations is greater than the threshold
-    type: boolean
-    default: false
     required: false
+    default: "false"
   github_token:
     description: GitHub token
     default: ${{ github.token }}

--- a/main.sh
+++ b/main.sh
@@ -10,7 +10,7 @@ throw() {
 [ -z "$API_KEY" ] && throw "API_KEY required"
 [ -z "$SERVER_URL" ] && throw "SERVER_URL required"
 [ -z "$COMMIT_SHA" ] && throw "COMMIT_SHA required"
-[ -z "$ISSUES_OVER_A11Y_THRESHOLD" ]
+[ -z "$ENABLE_A11Y_THRESHOLD" ] && throw "ENABLE_A11Y_THRESHOLD required"
 
 RETRY_COUNT=${RETRY_COUNT:-10}
 
@@ -27,7 +27,7 @@ Response=$(
     --url "$SERVER_URL/api-pub/v1/axe-watcher/gh/$COMMIT_SHA"
 )
 
-if [ -n "${ISSUES_OVER_A11Y_THRESHOLD+x}" ] && [ "$ISSUES_OVER_A11Y_THRESHOLD" = true ]; then
+if [ -n "${ENABLE_A11Y_THRESHOLD+x}" ] && [ "$ENABLE_A11Y_THRESHOLD" = true ]; then
   IssueCount=$(echo "$Response" | jq .issues_over_a11y_threshold)
 else
   IssueCount=$(echo "$Response" | jq .last_run_violation_count)

--- a/main.sh
+++ b/main.sh
@@ -10,6 +10,7 @@ throw() {
 [ -z "$API_KEY" ] && throw "API_KEY required"
 [ -z "$SERVER_URL" ] && throw "SERVER_URL required"
 [ -z "$COMMIT_SHA" ] && throw "COMMIT_SHA required"
+[ -z "$ISSUES_OVER_A11Y_THRESHOLD" ]
 
 RETRY_COUNT=${RETRY_COUNT:-10}
 
@@ -26,7 +27,12 @@ Response=$(
     --url "$SERVER_URL/api-pub/v1/axe-watcher/gh/$COMMIT_SHA"
 )
 
-IssueCount=$(echo "$Response" | jq .last_run_violation_count)
+if [ -n "${ISSUES_OVER_A11Y_THRESHOLD+x}" ] && [ "$ISSUES_OVER_A11Y_THRESHOLD" = true ]; then
+  IssueCount=$(echo "$Response" | jq .issues_over_a11y_threshold)
+else
+  IssueCount=$(echo "$Response" | jq .last_run_violation_count)
+fi
+
 AxeURL=$(echo "$Response" | jq -r .axe_url)
 ProjectName=$(echo "$Response" | jq -r .project_name)
 

--- a/main.sh
+++ b/main.sh
@@ -27,7 +27,7 @@ Response=$(
     --url "$SERVER_URL/api-pub/v1/axe-watcher/gh/$COMMIT_SHA"
 )
 
-if [ -n "${ENABLE_A11Y_THRESHOLD+x}" ] && [ "$ENABLE_A11Y_THRESHOLD" = true ]; then
+if [ "$ENABLE_A11Y_THRESHOLD" = "true" ]; then
   IssueCount=$(echo "$Response" | jq .issues_over_a11y_threshold)
 else
   IssueCount=$(echo "$Response" | jq .last_run_violation_count)


### PR DESCRIPTION
This PR adds an optional input to block PRs based on issues over the a11y threshold set within DeveloperHub


Ref: https://github.com/dequelabs/walnut/issues/5888