### PR TITLE
ci: remove chrome and chromedriver in example

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           node-version: 18
       - run: cd example && npm install
-      - uses: browser-actions/setup-chrome@latest
-      - uses: nanasess/setup-chromedriver@v2
       - run: cd example && npm run build
       - name: Run tests
         run: xvfb-run --auto-servernum npm run ci


### PR DESCRIPTION
we can rely on GHA as it has chrome and chromedriver installed

ref: https://github.com/dequelabs/axe-devhub-action/actions/runs/5757694345/job/15609115054?pr=97#step:6:13