### PR TITLE
chore: amend `update-watcher.yml` to only install stable versions

### DIFF
--- a/.github/workflows/update-watcher.yml
+++ b/.github/workflows/update-watcher.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: cd example && npm install --save-dev @axe-core/watcher@next
+      - run: cd example && npm install --save-dev @axe-core/watcher@latest
       - name: Open PR
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5
         with:
@@ -24,5 +24,5 @@ jobs:
           base: main
           title: "chore: Update @axe-core/watcher"
           body: |
-            This patch updates version of [`@axe-core/watcher`](https://npmjs.org/@axe-core/watcher) to the latest `@next` version.
+            This patch updates version of [`@axe-core/watcher`](https://npmjs.org/@axe-core/watcher) to the latest version.
             This PR was opened by a robot :robot: :tada:.


### PR DESCRIPTION
This PR adds the following: 

- Discussed during standup this should only really update to the latest stable version for watcher for the example we're providing