### PR TITLE
fix(gha): displays extra data in gha output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ A full example of the `axe-devhub-action` can be seen at [`.github/workflows/tes
 
 ## Outputs
 
-| name          | description                                        |
-| ------------- | -------------------------------------------------- |
-| `project`     | Project associated with your API key               |
-| `axe_url`     | URL for viewing axe issues detected on your commit |
-| `issue_count` | Number of axe issues detected                      |
+| name                         | description                                        |
+| ---------------------------- | -------------------------------------------------- |
+| `project`                    | Project associated with your API key               |
+| `axe_url`                    | URL for viewing axe issues detected on your commit |
+| `issue_count`                | Number of axe issues detected                      |
+| `created_at`                 | DateTime when run occurred                         |
+| `resolved_issues`            | Number of axe issues resolved                      |
+| `difference_in_page_states`  | Difference in number of page states detected       |
+| `page_states`                | Number of page states detected                     |
+| `issues_over_a11y_threshold` | Number of issues over a11y threshold               |

--- a/main.sh
+++ b/main.sh
@@ -64,8 +64,11 @@ echo "$existing_issues_count previous issues remain"
 
 if [ "$DifferenceInPageStateCount" -gt 0 ]; then
   echo "$DifferenceInPageStateCount more page states"
+elif [ "$DifferenceInPageStateCount" -lt 0 ]; then
+  AbsoluteDifference=$(( -DifferenceInPageStateCount ))
+  echo "$AbsoluteDifference fewer page states"
 else
-  echo "$DifferenceInPageStateCount fewer page states"
+  echo "No change in page state count"
 fi
 
 if [ "$ENABLE_A11Y_THRESHOLD" = "true" ]; then 

--- a/main.sh
+++ b/main.sh
@@ -27,27 +27,50 @@ Response=$(
     --url "$SERVER_URL/api-pub/v1/axe-watcher/gh/$COMMIT_SHA"
 )
 
-IssueCount=$(echo "$Response" | jq .last_run_violation_count)
+LastRunViolationCount=$(echo "$Response" | jq .last_run_violation_count)
+LastRunPageStateCount=$(echo "$Response" | jq -r .last_run_page_state_count)
+LastRunNewViolationCount=$(echo "$Response" | jq -r .last_run_new_violation_count)
+LastRunResolvedViolationCount=$(echo "$Response" | jq -r .last_run_resolved_violation_count)
 IssuesOverA11yThreshold=$(echo "$Response" | jq .issues_over_a11y_threshold)
 AxeURL=$(echo "$Response" | jq -r .axe_url)
 ProjectName=$(echo "$Response" | jq -r .project_name)
+DifferenceInPageStateCount=$(echo "$Response" | jq -r .difference_in_page_states)
 
 # Only set outs when running in GitHub Actions.
 if [ -n "${GITHUB_OUTPUT+x}" ]; then
   echo "project=$ProjectName" >>"$GITHUB_OUTPUT"
   echo "axe_url=$SERVER_URL$AxeURL" >>"$GITHUB_OUTPUT"
-  echo "issue_count=$IssueCount" >>"$GITHUB_OUTPUT"
+  echo "issue_count=$LastRunViolationCount" >>"$GITHUB_OUTPUT"
+  echo "new_issues=$LastRunNewViolationCount" >> "$GITHUB_OUTPUT"
+  echo "resolved_issues=$LastRunResolvedViolationCount" >> "$GITHUB_OUTPUT"
   echo "issues_over_a11y_threshold=$IssuesOverA11yThreshold" >>"$GITHUB_OUTPUT"
+  echo "difference_in_page_states=$DifferenceInPageStateCount" >> "$GITHUB_OUTPUT"
+  echo "page_states=$LastRunPageStateCount" >> "$GITHUB_OUTPUT"
 fi
 
 echo "Project: $ProjectName"
-echo "axe DevHub found $IssueCount accessibility violations."
+echo "axe Developer Hub accessibility results:"
+echo "$LastRunViolationCount violations found"
+echo "$LastRunPageStateCount page states found"
+echo "$LastRunNewViolationCount new issues found"
+echo "$LastRunResolvedViolationCount issues resolved"
 
-if [ "$ENABLE_A11Y_THRESHOLD" = "true" ]; then 
-  echo "axe DevHub found $IssuesOverA11yThreshold accessibility violations over your a11y threshold."
+existing_issues_count=$(( $LastRunViolationCount - $LastRunNewViolationCount ))
+existing_issues_count=$(( existing_issues_count < 0 ? 0 : existing_issues_count ))
+
+echo "$existing_issues_count previous issues remain"
+
+if [ "$DifferenceInPageStateCount" -gt 0 ]; then
+  echo "$DifferenceInPageStateCount more page states"
+else
+  echo "$DifferenceInPageStateCount fewer page states"
 fi
 
-echo "See the full report on axe DevHub: $SERVER_URL$AxeURL"
+if [ "$ENABLE_A11Y_THRESHOLD" = "true" ]; then 
+  echo "$IssuesOverA11yThreshold accessibility violations over your a11y threshold."
+fi
+
+echo "See full report at $SERVER_URL$AxeURL"
 
 
 if [ "$ENABLE_A11Y_THRESHOLD" = "true" ]; then
@@ -59,6 +82,6 @@ if [ "$ENABLE_A11Y_THRESHOLD" = "true" ]; then
   fi
 fi
 
-if [ "$IssueCount" -gt 0 ]; then
+if [ "$LastRunViolationCount" -gt 0 ]; then
   exit 1
 fi

--- a/main.sh
+++ b/main.sh
@@ -27,7 +27,8 @@ Response=$(
     --url "$SERVER_URL/api-pub/v1/axe-watcher/gh/$COMMIT_SHA"
 )
 
-LastRunViolationCount=$(echo "$Response" | jq .last_run_violation_count)
+LastRunCreatedAt=$(echo "$Response" | jq -r .last_run_created_at)
+LastRunViolationCount=$(echo "$Response" | jq -r .last_run_violation_count)
 LastRunPageStateCount=$(echo "$Response" | jq -r .last_run_page_state_count)
 LastRunNewViolationCount=$(echo "$Response" | jq -r .last_run_new_violation_count)
 LastRunResolvedViolationCount=$(echo "$Response" | jq -r .last_run_resolved_violation_count)
@@ -40,6 +41,7 @@ DifferenceInPageStateCount=$(echo "$Response" | jq -r .difference_in_page_states
 if [ -n "${GITHUB_OUTPUT+x}" ]; then
   echo "project=$ProjectName" >>"$GITHUB_OUTPUT"
   echo "axe_url=$SERVER_URL$AxeURL" >>"$GITHUB_OUTPUT"
+  echo "created_at=$LastRunCreatedAt" >>"$GITHUB_OUTPUT"
   echo "issue_count=$LastRunViolationCount" >>"$GITHUB_OUTPUT"
   echo "new_issues=$LastRunNewViolationCount" >> "$GITHUB_OUTPUT"
   echo "resolved_issues=$LastRunResolvedViolationCount" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR adds additional data to the output of the `axe-devhub-action`.

Note: I may need to change the names of the variables we're outputting to be in line with what we use, but I'm not sure of this yet. @Zidious @dbjorge - Perhaps one of you can guide me on this?


QA Notes
1. Use `axe-devhub-action` in your CI process
2. Observe action output after a run

ref: [#1219](https://github.com/dequelabs/jazzband/issues/1219)