### PR TITLE
ci: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dequelabs/axe-api-team
+* @dequelabs/team-bass


### PR DESCRIPTION
I was wondering why we the team was not seeing this PR as stale. Updated to the new team for stale tracking

no qa required