### PR TITLE
fix(workflow): change results-team-project-management

### DIFF
--- a/.github/workflows/results-team-project-management.yml
+++ b/.github/workflows/results-team-project-management.yml
@@ -3,18 +3,12 @@ name: Results Team Project Management
 on:
   issues:
     types: [closed, labeled]
-  pull_request:
-    types: [opened, reopened, synchronize]
-    branches:
-      # Only run on this branch to set PR reviewers, which is the main branch for active development.
-      # We don't want to set reviewers for PRs opened against other branches.
-      - main
 
 concurrency:
   # Cancel in-progress runs only for the exact same event on the same issue/PR.
   # e.g. two 'labeled' events with the same label on the same issue will cancel the previous,
   # but 'closed' and 'labeled' or two different labels will run in parallel.
-  group: "${{ github.workflow }}-${{ github.event.action }}-${{ github.event.label.name || '' }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+  group: "${{ github.workflow }}-${{ github.event.action }}-${{ github.event.label.name || '' }}-${{ github.event.issue.number }}"
   cancel-in-progress: true
 
 jobs:
@@ -50,13 +44,5 @@ jobs:
       repo-name: ${{ github.event.repository.name }}
       repo-owner: ${{ github.repository_owner }}
       project-number: 188
-    secrets:
-      token: ${{ secrets.PAT }}
-
-  set-pr-reviewer:
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-    uses: dequelabs/results-team/.github/workflows/set-pr-reviewer-based-on-issue-label.yml@main
-    with:
-      pull-request-number: ${{ github.event.pull_request.number }}
     secrets:
       token: ${{ secrets.PAT }}

--- a/.github/workflows/results-team-project-management.yml
+++ b/.github/workflows/results-team-project-management.yml
@@ -3,17 +3,23 @@ name: Results Team Project Management
 on:
   issues:
     types: [closed, labeled]
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      # Only run on this branch to set PR reviewers, which is the main branch for active development.
+      # We don't want to set reviewers for PRs opened against other branches.
+      - main
 
 concurrency:
   # Cancel in-progress runs only for the exact same event on the same issue/PR.
   # e.g. two 'labeled' events with the same label on the same issue will cancel the previous,
   # but 'closed' and 'labeled' or two different labels will run in parallel.
-  group: "${{ github.workflow }}-${{ github.event.action }}-${{ github.event.label.name || '' }}-${{ github.event.issue.number }}"
+  group: "${{ github.workflow }}-${{ github.event.action }}-${{ github.event.label.name || '' }}-${{ github.event.issue.number || github.event.pull_request.number }}"
   cancel-in-progress: true
 
 jobs:
   add-docs-labels:
-    if: github.event_name == 'issues' && github.event.action == 'closed' && github.event.issue.state_reason == 'completed'
+    if: github.event_name == 'issues' && github.event.action == 'closed' && github.event.issue.state_reason == 'completed' && contains(github.event.issue.labels.*.name, 'team-results')
     uses: dequelabs/results-team/.github/workflows/add-docs-labels-on-close.yml@main
     with:
       issue-number: ${{ github.event.issue.number }}
@@ -21,7 +27,7 @@ jobs:
       token: ${{ secrets.PAT }}
 
   check-issue-closed-or-labeled:
-    if: github.event_name == 'issues'
+    if: github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'team-results')
     uses: dequelabs/results-team/.github/workflows/check-issue-is-closed-or-labeled.yml@main
     with:
       action: ${{ github.event.action }}
@@ -31,15 +37,26 @@ jobs:
       repo-name: ${{ github.event.repository.name }}
       repo-owner: ${{ github.repository_owner }}
       issue-url: ${{ github.event.issue.html_url }}
+      team-label: 'team-results'
+      project-number: 188
     secrets:
       token: ${{ secrets.PAT }}
 
   set-date-closed:
-    if: github.event_name == 'issues' && github.event.action == 'closed'
+    if: github.event_name == 'issues' && github.event.action == 'closed' && contains(github.event.issue.labels.*.name, 'team-results')
     uses: dequelabs/results-team/.github/workflows/set-date-closed-on-issue-close.yml@main
     with:
       issue-number: ${{ github.event.issue.number }}
       repo-name: ${{ github.event.repository.name }}
       repo-owner: ${{ github.repository_owner }}
+      project-number: 188
+    secrets:
+      token: ${{ secrets.PAT }}
+
+  set-pr-reviewer:
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    uses: dequelabs/results-team/.github/workflows/set-pr-reviewer-based-on-issue-label.yml@main
+    with:
+      pull-request-number: ${{ github.event.pull_request.number }}
     secrets:
       token: ${{ secrets.PAT }}


### PR DESCRIPTION
This pull request updates the `results-team-project-management.yml` GitHub workflow to ensure that jobs only run for issues labeled with `team-results`, and adds project-specific parameters to relevant workflow steps.

> [!WARNING]
> This PR must be merged after
> - https://github.com/dequelabs/results-team/pull/308

Ref: [results-team #307](https://github.com/dequelabs/results-team/issues/307)